### PR TITLE
Make GitHub link clickable

### DIFF
--- a/guides.md
+++ b/guides.md
@@ -7,7 +7,7 @@ permalink: /guides/
 
 The TODO Group in collaboration with the Linux Foundation and wider open source community helped produce a set of guides to aid companies developing open source programs:
 
-https://github.com/todogroup/guides
+[https://github.com/todogroup/guides](https://github.com/todogroup/guides)
 
 If you're company is looking to establish an open source program, we highly recommend you take a look at the various guides and see what you can learn.
 


### PR DESCRIPTION
The link is currently not clickable on the website.