### PR TITLE
Fix print styling

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -267,3 +267,14 @@ footer {
     }
   }
 }
+
+@media only print {
+  footer {
+    display: none;
+  }
+
+  article {
+    line-height: normal;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
I recently printed out one of the guides for offline reading, and found that a number of lines got cut off due to the footer being printed on every page. I also ended up with an arguably excessive number of pages, due to the double-spaced lines, and large font size. (These same issues exist when "printing" to PDF.)

This introduces a small bit of print-specific CSS to fix both of those issues.

Before:
<img width="1002" alt="Screen Shot 2020-01-21 at 1 52 18 PM" src="https://user-images.githubusercontent.com/37809/72833763-7c172600-3c55-11ea-8475-4baec8198bf9.png">

After:
<img width="1002" alt="Screen Shot 2020-01-21 at 1 54 31 PM" src="https://user-images.githubusercontent.com/37809/72833822-981ac780-3c55-11ea-9641-a57d367d7a2b.png">

Notice, no more footer displayed, and the page count is cut in half!