### PR TITLE
casestudies/uber.md: fix links in intro

### DIFF
--- a/content/en/guides/casestudies/uber.md
+++ b/content/en/guides/casestudies/uber.md
@@ -4,7 +4,7 @@ title: Uber
 
 Uber is one of the best-known disruptors in the digital age. Its business model famously separated transportation services from the traditional underlying infrastructure with an app-based model offering on-demand and multimodal options. In many ways,  this transformation, and Uber itself, also mirror the creative and collaborative aspects of the open source community.
 
-> "Uber has been an open source software user since the beginning," said[ Brian Hsieh](https://www.linkedin.com/in/briankhsieh/), head of open source at Uber. “But over the years, Uber has also contributed to the community and created many popular projects like[ Jaeger](https://www.jaegertracing.io/),[ Horovod](https://github.com/horovod/horovod),[ ](https://kepler.gl/)[Ludwig](http://ludwig.ai)[, ](https://kepler.gl/)[kepler.gl](https://kepler.gl/),[ deck.gl](https://deck.gl/#/), and[ Pyro](https://pyro.ai/).”
+> "Uber has been an open source software user since the beginning," said [Brian Hsieh](https://www.linkedin.com/in/briankhsieh/), head of open source at Uber. “But over the years, Uber has also contributed to the community and created many popular projects like [Jaeger](https://www.jaegertracing.io/), [Horovod](https://github.com/horovod/horovod), [Ludwig](http://ludwig.ai), [kepler.gl](https://kepler.gl/), [deck.gl](https://deck.gl/#/), and [Pyro](https://pyro.ai/).”
 
 The relationship between Uber and open source has evolved over time, driving each other forward.
 
@@ -14,11 +14,11 @@ The relationship between Uber and open source has evolved over time, driving eac
 
 Uber has a long history of contributing to open source projects. The company also has many active maintainers in the community. Since its earliest days, company developers contributed to PyTorch, TensorFlow, Kubeflow, OpenTracing, Cassandra, Chef, Arrow, Go, Buck, Kafka, Hive, Mesos, Redis, Swift, Gradle, Gym, Parquet, Presto, Spark, Kubernates, and more. The company’s first public project on GitHub was created in 2012, only three years after  Uber was founded. Far from its peak, the momentum behind Uber’s internal commitment to open source steamed ahead.
 
-> "Open sourcing deck.gl in 2015 was the start of a booming open source culture at Uber. It was another defining moment for Uber’s open source program when we open sourced Jaeger in 2016, and later [contributed it to the Cloud Native Computing Foundation](https://www.cncf.io/blog/2017/09/13/cncf-hosts-jaeger/) ([CNCF) ](https://www.cncf.io/blog/2017/09/13/cncf-hosts-jaeger/)in 2017," said Hsieh.
+> "Open sourcing deck.gl in 2015 was the start of a booming open source culture at Uber. It was another defining moment for Uber’s open source program when we open sourced Jaeger in 2016, and later [contributed it to the Cloud Native Computing Foundation](https://www.cncf.io/blog/2017/09/13/cncf-hosts-jaeger/) ([CNCF](https://www.cncf.io/blog/2017/09/13/cncf-hosts-jaeger/)) in 2017," said Hsieh.
 
 It was a defining moment in that it cemented Uber’s footprint in open source among the external community, even as it encouraged others at the company to consider the benefits of open sourcing their projects among developers internally.
 
-> "Then[ Horovod](http://horovod.ai/), now hosted by the[ LF AI Foundation](https://www.linuxfoundation.org/press-release/2018/12/lf-deep-learning-welcomes-horovod-distributed-training-framework-as-newest-project/), and[ Jaeger](https://jaegertracing.io/) both were on InfoWorld’s best open source software rankings in 2018. Horovod was also named a Top Technology of 2019 by[ InfoWorld](https://www.infoworld.com/article/3336072/infoworlds-2019-technology-of-the-year-award-winners.html). We are very proud of what we have contributed to the community and are thrilled that the community has found these projects useful," said Hsieh.
+> "Then [Horovod](http://horovod.ai/), now hosted by the [LF AI Foundation](https://www.linuxfoundation.org/press-release/2018/12/lf-deep-learning-welcomes-horovod-distributed-training-framework-as-newest-project/), and [Jaeger](https://jaegertracing.io/) both were on InfoWorld’s best open source software rankings in 2018. Horovod was also named a Top Technology of 2019 by [InfoWorld](https://www.infoworld.com/article/3336072/infoworlds-2019-technology-of-the-year-award-winners.html). We are very proud of what we have contributed to the community and are thrilled that the community has found these projects useful," said Hsieh.
 
 This string of successes solidified Uber’s open source program as a mature and prioritized investment. To encourage ongoing, regular involvement in open source projects, Uber instituted internal standards for governing and incentivizing contributing upstream and back to the community. For Uber, contributing back to the community is one of the best ways to help ensure open source project sustainability.
 
@@ -28,7 +28,7 @@ This string of successes solidified Uber’s open source program as a mature and
 
 Those "greater opportunities and innovations" tend to spread outwards to create a greater good. This year, in 2019, Uber helped launch the  [Urban Computing Foundation](https://uc.foundation/announcement/2019/05/07/linux-foundation-supports-community-development-to-improve-mobility-transportation-safety-and-infrastructure-with-new-urban-computing-foundation/) to support community development to improve mobility, transportation, safety, and infrastructure.
 
-Projects such as[ kepler.gl](https://kepler.gl/) can help urban planners, policymakers, and local governments, gain critical insights and better understand data about their cities. For example, you can use kepler.gl with anonymized and aggregated data from Uber’s [Movement](https://movement.uber.com/?lang=en-US) tool to visualize traffic patterns in a specific urban environment.
+Projects such as [kepler.gl](https://kepler.gl/) can help urban planners, policymakers, and local governments, gain critical insights and better understand data about their cities. For example, you can use kepler.gl with anonymized and aggregated data from Uber’s [Movement](https://movement.uber.com/?lang=en-US) tool to visualize traffic patterns in a specific urban environment.
 
 ## Uber’s OSPO from inception until now
 
@@ -36,7 +36,7 @@ Projects such as[ kepler.gl](https://kepler.gl/) can help urban planners, policy
 
 > "Our open source program was informally created by passionate engineers. With the blessing of our engineering leadership and support from our IP attorneys, the program was set up for success at the beginning. It provided a great foundation for what the program is today," said Hsieh.
 
-The impetus behind formalizing Uber’s OSPO came from several open source activities, with each requiring more organized support. For example, engineers needed guidance on how open source technology could be used in external products. Compliance, licensing, and other[ legal issues](https://opensource.guide/legal/) were among the most pressing. Another top consideration was to provide guidance for engineers on releasing Uber’s proprietary software in open source, either by creating a new project or contributing to the upstream.
+The impetus behind formalizing Uber’s OSPO came from several open source activities, with each requiring more organized support. For example, engineers needed guidance on how open source technology could be used in external products. Compliance, licensing, and other [legal issues](https://opensource.guide/legal/) were among the most pressing. Another top consideration was to provide guidance for engineers on releasing Uber’s proprietary software in open source, either by creating a new project or contributing to the upstream.
 
 > "The goal of the program office is really to make sure that all of Uber’s open source activities support our business either through processes, policies, or education. We need to make sure that we meet these expectations across our open source activities and remain a good open source citizen," said Hsieh.
 


### PR DESCRIPTION
The links in the intro on https://todogroup.org/guides/casestudies/uber/ were utterly broken, a big button on the page invited to come to github and fix it :-)

it seems the renderer on the main page is challenged by empty `[ ](...)` links 
- removed duplicate link to kepler.gl, cleaned up the others.
- cleaned up some more links further down in the document

![image](https://user-images.githubusercontent.com/209031/84079042-2a8bef80-a9da-11ea-8af1-1b0d72d59bf7.png)