### PR TITLE
use black text for Xilinx logo

### DIFF
--- a/static/img/logo_xilinx.svg
+++ b/static/img/logo_xilinx.svg
@@ -5,7 +5,7 @@
 <style type="text/css">
 	.st0{fill:#E01F27;}
 	.st1{fill:#801517;}
-	.st2{fill:#FFFFFF;}
+	.st2{fill:#000000;}
 	.st3{fill:#171C2D;}
 </style>
 <polygon class="st0" points="0,8.7 7.6,0 18.7,0 11.1,8.7 "/>


### PR DESCRIPTION
fixes the immediate accessibility issue mentioned in #175, but not the broader question of poorly sized logos in general.