### PR TITLE
comms.md: update slack and mailing list

### DIFF
--- a/content/en/comms.md
+++ b/content/en/comms.md
@@ -7,8 +7,8 @@ url: "/community/comms/"
 Are you new to our community? We invite you to join us on the different communication Channels:
 {{< /intro >}}
 
-* [Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-169ok18cz-Pi6tpVHTeW9254d1FpkLew): Includes OSPOlogy and TODO Member communication channels
-* [OSPOlogy Community Mailing List](https://docs.google.com/forms/d/e/1FAIpQLSeU0YGM_IJ6gY8E5IIiwXKD_FZi3kAVc4E9_-3dtTDyKMSjdA/viewform)
+* [Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-2w71kclgx-JOUB4LTXIuVEKehkJk7V0w): Includes OSPOlogy and TODO Member communication channels
+* [OSPOlogy Community Mailing List](https://lists.todogroup.org/g/community/)
 * [OSPOlogy Forum (GH Discussions)](https://github.com/todogroup/ospology/discussions)
 
 **OSPOlogy Regional Communication Channels**


### PR DESCRIPTION
This PR updates Slack link which is no longer working with the working one.

Mailing list link is also updated to the working one. The old google group is deprecated and groups.io is used instead.