### PR TITLE
fix broken wordtimebuddy.com link

### DIFF
--- a/content/en/meetings.md
+++ b/content/en/meetings.md
@@ -42,7 +42,7 @@ TODO Working Groups are open to everyone! Participating in them is the best way 
 
 📥 Get this calendar in [iCal](https://calendar.google.com/calendar/ical/c_cpd890ckcd8lgtqak65o6413ts%40group.calendar.google.com/public/basic.ics) format
 
-🕐 Need help with timezone conversions? Check out [worldtimebuddy.com](worldtimebuddy.com).
+🕐 Need help with timezone conversions? Check out [worldtimebuddy.com](https://www.worldtimebuddy.com).
 {{< todo_community_calendar >}}
 
 ## Other Calendars of Interest


### PR DESCRIPTION
Previous Markdown link [worldtimebuddy.com](worldtimebuddy.com) directs to https://todogroup.org/community/meetings/worldtimebuddy.com and 404.

Proposed change adds full URL to direct to https://www.worldtimebuddy.com/ .