### PR TITLE
Add blog post about Agentic AI OSPOs Working Group

### DIFF
--- a/content/en/blog/agentic-ai-ospo-wg-launch.md
+++ b/content/en/blog/agentic-ai-ospo-wg-launch.md
@@ -1,0 +1,47 @@
+---
+title: Introducing the Agentic AI to Empower OSPOs Working Group
+author: todogroup
+date: 2026-05-05
+---
+
+Open Source Program Offices have spent the last decade getting good at scale: scaling compliance reviews, scaling contribution workflows, 
+scaling community engagement across hundreds of projects and thousands of repositories. Agentic AI (LLM‑driven systems that can plan, 
+take action, and operate across tools) raises a new set of questions that OSPOs are being asked to answer on behalf of their organizations. That's why TODO Group 
+is launching a new Working Group: **Agentic AI to Empower OSPOs**.
+
+## Why this Working Group
+
+Two trends are converging on the OSPO desk at the same time:
+
+- The first is internal; OSPO teams are seeing genuine, repeatable use cases for AI agents in their own workflows (license review, SBOM analysis, contribution triage,
+policy enforcement, documentation, FAQ generation, onboarding, executive reporting). The work is high‑volume, pattern‑heavy, and previously bottlenecked on human attention.
+Agents can handle a meaningful share of it well, when set up with the right guardrails.
+
+- The second is external; As organizations adopt AI tooling, they are turning to their OSPOs for guidance: How do we evaluate the license of a model? What does it mean to release
+an "open source" AI system? How should we govern AI‑generated contributions to projects we maintain? Where does responsible adoption start? OSPOs that previously focused on traditional
+open source software are now being asked to extend that judgment into a much messier ecosystem.
+
+Neither conversation is well served by a single OSPO working in isolation. Patterns, lessons, and tooling are emerging quickly across the community — but they are scattered across blog posts, internal docs, and ad‑hoc Slack threads. A dedicated Working Group is the right shape to consolidate that learning into something practitioners can actually use.
+
+## What the Working Group will work on
+
+The group’s themes may include, but are not limited to:
+
+- Practical use cases for AI agents inside OSPOs: Surfacing what is working today, what is not, and the operational patterns behind successful deployments. Compliance, contribution review, community moderation, internal documentation, and reporting are early areas of focus
+- Tooling evaluation: Looking at the open source agent frameworks, model options, and integration patterns OSPOs are using or considering.
+- Governance and policy implications: AI agents acting on behalf of an organization create new questions about accountability, audit, license obligations, and contribution provenance. 
+
+## Connection to TODO's broader 2026 direction
+
+The Working Group fits directly into one of TODO's 2026 priorities: evolving the OSPO narrative around AI, policy, and measurable value. 
+AI is no longer a separate track from open source management, but it is becoming part of how organizations adopt, contribute to, and govern open source. 
+Building practitioner‑grounded resources here keeps OSPOs ahead of the questions their leadership and legal teams are starting to ask.
+
+## How to get involved
+
+The Working Group is about to start its first meeting call by mid-May and is open to anyone in the OSPO ecosystem: IT and business managers, legal partners, project maintainers, developers relations leads, and open source
+management professionals interested in the intersection of open source management and AI.
+
+- **Repository**: [todogroup/working-groups/wg-agentic-ai](https://github.com/todogroup/working-groups/tree/main/wg-agentic-ai)
+- **Slack**: `#wg-agentic-ai-ospo` in the [TODO Group Slack](https://join.slack.com/t/thetodogroup/shared_invite/zt-2w71kclgx-JOUB4LTXIuVEKehkJk7V0w)
+- **Bi‑weekly call**: see the [TODO Group Community Calendar](https://todogroup.org/community/meetings/)


### PR DESCRIPTION
This new blog post introduces the Agentic AI to Empower OSPOs Working Group, outlining its purpose, focus areas, and how to get involved.