### PR TITLE
fix(members): auto-resize landscape iframe so all members render

### DIFF
--- a/layouts/shortcodes/todo_group_members.html
+++ b/layouts/shortcodes/todo_group_members.html
@@ -7,11 +7,6 @@
   scrolling="no"
   width="1000"
   loading="lazy"
-  style="width: 1px; min-width: 100%; opacity: 1; visibility: visible; overflow: hidden;"
+  style="width: 1px; min-width: 100%; height: 2600px; border: 0;"
   title="List of all TODO Group General Members"
 ></iframe>
-
-<script src="https://landscape.todogroup.org/iframeResizer.js"></script>
-<script>
-  iFrameResize({ log: false, checkOrigin: false }, '#landscape');
-</script>

--- a/layouts/shortcodes/todo_group_members.html
+++ b/layouts/shortcodes/todo_group_members.html
@@ -1,13 +1,17 @@
-<!-- Embed list of all Open Mainframe Project members -->
-<iframe 
-  src="https://landscape.todogroup.org/embed/embed.html?key=todo-group-member--general&headers=true&category-header=false&category-in-subcategory=true&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=15&style=clean&size=lg&items-alignment=left&bg-color=%23fdfdfd&fg-color=%238f8f8f" 
-  frameborder="0"
+<!-- Embed list of all TODO Group Project members -->
+
+<iframe
+  src="https://landscape.todogroup.org/embed/embed.html?key=todo-group-member--general&headers=true&category-header=false&category-in-subcategory=true&item-name=false&title-uppercase=false&title-alignment=left&title-font-family=sans-serif&title-font-size=15&style=clean&size=lg&items-alignment=left&bg-color=%23fdfdfd&fg-color=%238f8f8f"
   id="landscape"
+  frameborder="0"
   scrolling="no"
   width="1000"
   loading="lazy"
-  style="width: 1px; min-width: 100%; opacity: 1; visibility: visible; overflow: hidden; height: 1717px;"
-  title="List of all Open Mainframe Project members"
+  style="width: 1px; min-width: 100%; opacity: 1; visibility: visible; overflow: hidden;"
+  title="List of all TODO Group General Members"
 ></iframe>
 
 <script src="https://landscape.todogroup.org/iframeResizer.js"></script>
+<script>
+  iFrameResize({ log: false, checkOrigin: false }, '#landscape');
+</script>


### PR DESCRIPTION
The members embed iframe had a hardcoded height, so once the members list grew past that height, the extra rows were clipped and couldn't be scrolled to. This change removes the hardcoded height